### PR TITLE
chore: upgrade actions/cache to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
         echo "DATABASE_URL=mysql://root@127.0.0.1/shopware" >> "$GITHUB_ENV"
 
     - name: Retrieve the cached "vendor" directory (if present)
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: composer-cache
       with:
         path: vendor


### PR DESCRIPTION
This change prevents deprecation warnings about using node16.

See:
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- https://github.com/actions/cache/releases/tag/v4.0.0
- https://github.com/actions/cache/pull/1284