### PR TITLE
feat: set COMPOSER_ROOT_VERSION

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "PHP extensions to install"
     required: true
     default: ""
+  composer-root-version:
+    description: "The COMPOSER_ROOT_VERSION that should be set"
+    required: false
+    default: ".auto"
   install:
     description: "Install Shopware"
     required: true
@@ -71,6 +75,16 @@ runs:
         repository: ${{ inputs.shopware-repository }}
         ref: ${{ inputs.shopware-version }}
         path: ${{ inputs.path }}
+
+    - name: Set COMPOSER_ROOT_VERSION
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: |
+        if [[ "${{ inputs.composer-root-version }}" == ".auto" ]]; then
+          echo "COMPOSER_ROOT_VERSION=$(jq -r '.extra | .["branch-alias"] | .["dev-trunk"]' composer.json)" >> "$GITHUB_ENV"
+        else
+          echo "COMPOSER_ROOT_VERSION=${{ inputs.composer-root-version }}" >> "$GITHUB_ENV"
+        fi
 
     - name: Remove vendor-bin
       if: inputs.keep-composer-tools == 'false'


### PR DESCRIPTION
When we are using a different branch than `trunk` the version of platform can't be determined. For this case we need to set `COMPOSER_ROOT_VERSION`.

If `composer-root-version` is set to `.auto` it will get the version from `composer.json`.