### PR TITLE
fix: correctly specify path for hashFiles

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -220,7 +220,7 @@ runs:
       working-directory: ${{ inputs.path }}
       run: |
         yq -n '.shopware.api.jwt_key.use_app_secret = true' | tee config/packages/zz-shopware.yaml
-      if: ${{ hashFiles('src/Core/Framework/Api/OAuth/JWTConfigurationFactory.php') != '' }}
+      if: ${{ hashFiles(format('{0}/src/Core/Framework/Api/OAuth/JWTConfigurationFactory.php', inputs.path)) != '' }}
 
     - name: Install Shopware
       if: inputs.install == 'true'


### PR DESCRIPTION
`hashFiles` is always evaluated in the [GITHUB_WORKSPACE](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#hashfiles), so we need to prepend the shopware root directory for the condition to correctly evaluate.