### PR TITLE
fix: use relative current-directory reference when inputs.path is empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -220,7 +220,7 @@ runs:
       working-directory: ${{ inputs.path }}
       run: |
         yq -n '.shopware.api.jwt_key.use_app_secret = true' | tee config/packages/zz-shopware.yaml
-      if: ${{ hashFiles(format('{0}/src/Core/Framework/Api/OAuth/JWTConfigurationFactory.php', inputs.path)) != '' }}
+      if: ${{ hashFiles(format('{0}/src/Core/Framework/Api/OAuth/JWTConfigurationFactory.php', (inputs.path || '.' ))) != '' }}
 
     - name: Install Shopware
       if: inputs.install == 'true'


### PR DESCRIPTION
In addition to [yesterday's change](https://github.com/shopware/setup-shopware/pull/12), this one is necessary to fix the ATS job in shopware/shopware. `inputs.path` is empty in that case and the rendered path given to `hashFiles` would be an absolute one otherwise.