### PR TITLE
fix: define ALLOW_ALL_IP to make the symfony dev server listen on IPv…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -259,4 +259,10 @@ runs:
       if: inputs.install == 'true'
       shell: bash
       working-directory: ${{ inputs.path }}
-      run: symfony server:start -d --no-tls --allow-http --port=8000
+      env:
+        SYMFONY_DAEMON: "1"
+        SYMFONY_NO_TLS: "1"
+        SYMFONY_ALLOW_HTTP: "1"
+        SYMFONY_PORT: "8000"
+        SYMFONY_ALLOW_ALL_IP: "1"
+      run: symfony server:start


### PR DESCRIPTION
…4 and IPv6 local interface

chore: replace flags with environment variables

---

This prevents errors like this one: https://github.com/shopware/shopware/actions/runs/11740672383/job/32707709686#step:5:33