### PR TITLE
feat: add npm version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -192,7 +192,7 @@ runs:
       if: ${{ inputs.install-admin }}
       shell: bash
       working-directory: ${{ inputs.path || '.' }}/src/Administration/Resources/app/administration
-      run: npm run unit-setup
+      run: npm run unit-setup --if-present
 
     - name: Entity schema
       if: ${{ inputs.install-admin }}

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: nodejs version to use
     required: false
     default: "20.x"
+  npm-version:
+    description: npm version to use
+    required: false
+    default: ""
   install-admin:
     description: Whether to install administration npm dependencies and prepare jest
     required: false
@@ -145,6 +149,12 @@ runs:
       if: inputs.install-storefront || inputs.install-admin
       with:
         node-version: ${{ inputs.node-version }}
+
+    - name: Install npm version
+      if: inputs.npm-version
+      shell: bash
+      run: |
+        npm install -g npm@${{ inputs.npm-version }}
 
     - name: Retrieve the cached "node_modules" directory (if present)
       uses: actions/cache@v4


### PR DESCRIPTION
Some plugins require older versions of npm.
When we now set `npm-version` it will install the specified npm version.

I also fixed the `npm run unit-setup`. Some older versions doesn't have such a npm script, so we only run it when it is present.