### PR TITLE
feat: add runs-on magic cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,7 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: runs-on/action@v1
     - name: Clone Shopware
       uses: actions/checkout@v4
       with:
@@ -293,7 +294,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.path }}
       run: |
-          bin/console assets:install
+        bin/console assets:install
 
     - name: Assign default Storefront theme to all sales channels
       if: inputs.install-storefront == 'true'


### PR DESCRIPTION
In v2.6.3 of runs-on they introduced a new feature named "Magic Cache". It redirects the cache calls for actions like `actions/cache` and `docker/build-push-action` to a S3 bucket, which is faster for our private runners.
If the action is run on a official runner, it just does nothing, so it is safe to be called on both runner types.