### PR TITLE
chore(ci): skip MySQL setup when using act

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
         tools: symfony-cli
 
     - name: Start Default MySQL
-      if: inputs.mysql-version == 'builtin'
+      if: inputs.mysql-version == 'builtin' && !github.event.act
       shell: bash
       run: |
         sudo mv /var/lib/mysql /var/lib/mysql-old


### PR DESCRIPTION
This requires of course using a `service`, but without this line it will fail locally, _even when_ specifying a `service`.