### PR TITLE
fix: Remove workaround for phpstan/phpdoc-parse as it is not needed anymore

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -56,11 +56,12 @@ jobs:
       matrix:
         version:
           - 'trunk'
+          - 'v6.5.8.9'
+          - 'v6.5.8.15'
           - 'v6.6.0.3'
           - 'v6.6.4.0'
           - 'v6.6.8.2'
-          - 'v6.5.8.15'
-          - 'v6.5.8.9'
+          - 'v6.6.10.3'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -106,20 +106,6 @@ runs:
       working-directory: ${{ inputs.path }}
       run: rm -rf vendor-bin
 
-    - name: Fix temporary PHPStan Failure
-      shell: bash
-      working-directory: ${{ inputs.path }}
-      run: |
-        if ! jq -e '.["require-dev"]["phpstan/phpdoc-parser"]' composer.json > /dev/null 2>&1; then
-            echo "phpstan/phpdoc-parser not found in require-dev, adding it..."
-
-            # Create a temporary file with the new content
-            jq '.["require-dev"]["phpstan/phpdoc-parser"] = "~1"' composer.json > composer.json.tmp
-
-            # Replace the original file
-            mv composer.json.tmp composer.json
-        fi
-
     - name: Setup PHP
       uses: shopware/setup-php@main
       env:

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   shopware-version:
     description: "Shopware Version to use"
     required: true
-    default: "v6.6.8.0"
+    default: "v6.6.10.3"
   shopware-repository:
     description: The shopware repository to checkout
     required: true


### PR DESCRIPTION
All PHPStan and PHPUnit dependencies are now on versions, that are working with the newest version of the phpdoc-parser. so this workaround is not needed anymore. 

We even worked around the workaround with requiring the 2.x version of it in the core :see_no_evil: 