### PR TITLE
fix: replace symfony-cli tool with pinned release install

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -24,6 +24,7 @@ jobs:
           mysql-version: ${{ matrix.mysql }}
           install: 'true'
           path: 'sw-test'
+          allow-insecure-versions: 'true'
 
   only-storefront:
     runs-on: ubuntu-latest
@@ -34,8 +35,9 @@ jobs:
         uses: ./.
         with:
           install: 'true'
-          installStorefront: 'true'
+          install-storefront: 'true'
           path: 'sw-test'
+          allow-insecure-versions: 'true'
 
   only-admin:
     runs-on: ubuntu-latest
@@ -46,8 +48,9 @@ jobs:
         uses: ./.
         with:
           install: 'true'
-          installAdmin: 'true'
+          install-admin: 'true'
           path: 'sw-test'
+          allow-insecure-versions: 'true'
 
   version-matrix:
     runs-on: ubuntu-latest
@@ -71,7 +74,7 @@ jobs:
           shopware-version: '${{ matrix.version }}'
           path: 'sw-test'
           install: 'true'
-          allow-insecure-versions: ${{ matrix.version == 'trunk' && 'false' || 'true' }}
+          allow-insecure-versions: 'true'
       - name: Show version
         working-directory: sw-test
         run: ./bin/console --version
@@ -86,6 +89,7 @@ jobs:
         with:
           install: 'true'
           path: 'sw-test'
+          allow-insecure-versions: 'true'
           disable-bundles: 'Administration, Storefront, Elasticsearch'
       - name: Verify bundles are disabled
         working-directory: sw-test

--- a/action.yml
+++ b/action.yml
@@ -167,8 +167,15 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.php-extensions }}
-        tools: symfony-cli
         ini-values: ${{ inputs.php-ini-values }}
+
+    - name: Install Symfony CLI
+      if: ${{ inputs.install == 'true' }}
+      uses: jaxxstorm/action-install-gh-release@v3.0.0
+      with:
+        repo: symfony-cli/symfony-cli
+        tag: v5.17.1
+        cache: enable
 
     - name: Prepare session dir
       shell: bash


### PR DESCRIPTION
Switching from the generic tools approach to jaxxstorm/action-install-gh-release
with a pinned version (v5.17.1) for more reliable Symfony CLI installation.
