### PR TITLE
fix: stop forcing github runner mode for setup-php

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -160,10 +160,6 @@ runs:
 
     - name: Setup PHP
       uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # ratchet:shivammathur/setup-php@2.37.2
-      env:
-        RUNNER: github
-        ImageOS: ubuntu
-        GITHUB_EMULATION: "true"
       with:
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.php-extensions }}


### PR DESCRIPTION
## Summary
- Remove the forced `RUNNER=github` / `ImageOS` / `GITHUB_EMULATION` env override from the Setup PHP step
- After the setup-php 2.37.2 bump in #46, that override conflicts with `RUNNER_ENVIRONMENT=self-hosted` on runs-on and aborts with `Runner set as github in self-hosted environment`
- Let setup-php auto-detect the runner so Rufus/downstream CI can set up again

## Test plan
- [ ] Merge and confirm a Rufus Downstream run using `setup-shopware@main` gets past Setup Rufus / Setup PHP
- [ ] Spot-check a workflow that uses this action on runs-on still installs the requested PHP version and extensions