### PR TITLE
fix: use RUNNER_ENVIRONMENT to keep setup-php on the prebuilt path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,9 +161,8 @@ runs:
     - name: Setup PHP
       uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # ratchet:shivammathur/setup-php@2.37.2
       env:
-        RUNNER: github
+        RUNNER_ENVIRONMENT: github-hosted
         ImageOS: ubuntu
-        GITHUB_EMULATION: "true"
       with:
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.php-extensions }}


### PR DESCRIPTION
setup-php 2.37 rejects a forced RUNNER=github when it detects a self-hosted environment and exits 1 with "Runner set as github in self-hosted environment". Since our runs-on runners report RUNNER_ENVIRONMENT=self-hosted, every job using this action broke when the pin moved from 2.33.0 to 2.37.2.

Override RUNNER_ENVIRONMENT instead. setup-php then resolves the runner to github by itself, so the conflict check no longer triggers and PHP is still installed from the prebuilt package rather than compiled from the ondrej PPA. The env is scoped to this step, so other actions keep seeing the real value.

GITHUB_EMULATION was never read by setup-php and is dropped.