### PR TITLE
feat: add patch-composer action for externally set up installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,28 @@ jobs:
                 shopware-repository: shopware/shopware
                 php-version: 8.1
                 install: true
+```
+
+## `patch-composer`
+
+`setup-shopware` already patches the installation it creates. Use this action to patch an **additional** Shopware installation that was set up by other means — typically an older version built with `composer require shopware/core:<version>` for update tests.
+
+Background: GitHub Actions issues `ghs_` installation tokens with JWT-style segments that `composer/composer` below 2.10 rejects in `BaseIO::loadConfiguration`, which makes commands like `bin/console system:install` fail. Composer 2.10+ dropped that validation (composer/composer#12856). Shopware versions that cap `composer/composer` below 2.10 cannot pick up the fix, so their vendored copy needs the same change applied.
+
+The action is a no-op when the vendored composer is 2.10 or newer, or when there is no vendored composer at all.
+
+| Name   | Description                                       | Default | Required |
+|--------|---------------------------------------------------|---------|----------|
+| `path` | Directory of the Shopware installation to patch.  | `.`     | false    |
+
+```yaml
+            - name: Require shopware
+              working-directory: old-shopware
+              run: composer require shopware/core:v6.6.0.0
+
+            - name: Patch vendored composer for modern GitHub tokens
+              uses: shopware/setup-shopware/patch-composer@main
+              with:
+                path: old-shopware
+```
 

--- a/patch-composer/action.yml
+++ b/patch-composer/action.yml
@@ -1,0 +1,17 @@
+name: "Patch vendored composer"
+description: "Patch a pre-2.10 vendored composer/composer to accept modern GitHub installation tokens"
+
+inputs:
+  path:
+    description: "Directory of the Shopware installation to patch"
+    required: false
+    default: "."
+
+runs:
+  using: composite
+  steps:
+    # Obsolete once no supported Shopware version pins composer/composer < 2.10.
+    - name: Patch composer github-oauth token validation
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: python3 "${{ github.action_path }}/../scripts/patch-composer-github-oauth.py"


### PR DESCRIPTION
`setup-shopware` patches the vendored `composer/composer` of the installation it creates, but update-test workflows build a second one afterwards (`composer require shopware/core:<old-version>`) that stays unpatched. `bin/console system:install` then fails on modern `ghs_` tokens — currently red on every 6.6.x run for the `v6.6.0.0` matrix entry. That version can't move to a fixed composer: it pins Symfony to `~7.0`, so 2.8.11 is the ceiling.

Exposes the existing `scripts/patch-composer-github-oauth.py` as a standalone action:

```yaml
- uses: shopware/setup-shopware/patch-composer@main
  with:
    path: old-shopware
```

The script stays the single source of truth; the root action keeps calling it directly, so tag-pinned consumers are unaffected.

Companion PR in `shopware/shopware` (6.6.x) wires this into `integration.yml`.